### PR TITLE
feat: 添加查重workflow

### DIFF
--- a/.github/workflows/check_dup.yml
+++ b/.github/workflows/check_dup.yml
@@ -1,0 +1,22 @@
+name: 查重
+on: [push, pull_request]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.18'
+
+      - name: Run Checker
+        run: |
+          ls
+          go mod tidy
+          go run check_dulplicate.go 5

--- a/check_dulplicate.go
+++ b/check_dulplicate.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"image"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	_ "golang.org/x/image/webp"
+
+	"github.com/corona10/goimagehash"
+)
+
+type imagecheck struct {
+	name string
+	dh   *goimagehash.ImageHash
+}
+
+func (ic *imagecheck) String() string {
+	return ic.name
+}
+
+func main() {
+	throttle, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	imgs, err := os.ReadDir("imgs")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Chdir("imgs")
+	if err != nil {
+		panic(err)
+	}
+	chklst := make([]imagecheck, 0, len(imgs))
+	wg := sync.WaitGroup{}
+	mu := sync.Mutex{}
+	part := len(imgs) / runtime.NumCPU()
+	wg.Add(runtime.NumCPU())
+	for i := 0; i < runtime.NumCPU(); i++ {
+		from := i * part
+		to := (i + 1) * part
+		if to > len(imgs) {
+			to = len(imgs)
+		}
+		go func(from, to int) {
+			for i := from; i < to; i++ {
+				img := imgs[i]
+				if !img.IsDir() {
+					f, err := os.Open(img.Name())
+					if err != nil {
+						panic(err)
+					}
+					im, _, err := image.Decode(f)
+					if err != nil {
+						panic(err)
+					}
+					dh, err := goimagehash.DifferenceHash(im)
+					if err != nil {
+						panic(err)
+					}
+					mu.Lock()
+					chklst = append(chklst, imagecheck{
+						name: img.Name(),
+						dh:   dh,
+					})
+					mu.Unlock()
+					_ = f.Close()
+				}
+			}
+			wg.Done()
+		}(from, to)
+	}
+	wg.Wait()
+	fmt.Println("read file success")
+	dups := make([][]*imagecheck, len(chklst))
+	for i := 0; i < len(chklst); i++ {
+		for j := len(chklst) - 1; j > i; j-- {
+			dis, err := chklst[i].dh.Distance(chklst[j].dh)
+			if err != nil {
+				panic(err)
+			}
+			if dis < throttle {
+				dups[i] = append(dups[i], &chklst[j])
+			}
+		}
+	}
+	hasfound := false
+	for i, lst := range dups {
+		if len(lst) > 0 {
+			lst = append(lst, &chklst[i])
+			fmt.Println("found dulplicate: ", lst)
+			hasfound = true
+		}
+	}
+	if hasfound {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module yydz
+
+go 1.18
+
+require (
+	github.com/corona10/goimagehash v1.0.3
+	golang.org/x/image v0.0.0-20220413100746-70e8d0d3baa9
+)
+
+require github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/corona10/goimagehash v1.0.3 h1:NZM518aKLmoNluluhfHGxT3LGOnrojrxhGn63DR/CZA=
+github.com/corona10/goimagehash v1.0.3/go.mod h1:VkvE0mLn84L4aF8vCb6mafVajEb6QYMHl2ZJLn0mOGI=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
+golang.org/x/image v0.0.0-20220413100746-70e8d0d3baa9 h1:LRtI4W37N+KFebI/qV0OFiLUv4GLOWeEW5hn/KEJvxE=
+golang.org/x/image v0.0.0-20220413100746-70e8d0d3baa9/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
添加这个workflows即可快速检查当前库中是否有相似图片，以及PR的新图片中是否有与现有图片相似的图片。
效果详见 https://github.com/fumiama/YYDZ/runs/6370321011
只要有相似的图片，就会使这个workflows失败并输出相似图片的文件名。
另外，可以通过调整`.github/workflows/check_dup.yml`的最后一行`go run check_dulplicate.go 5`的数字，指定判断为重复图片的阈值。